### PR TITLE
when applying the OETFs, take into account the black point levels

### DIFF
--- a/MHC2Gen/IccContext.cs
+++ b/MHC2Gen/IccContext.cs
@@ -354,6 +354,7 @@ namespace MHC2Gen
 
             var devicePrimaries = ProfilePrimaries;
 
+            var deviceEotf = new ToneCurve[] { profileRedToneCurve, profileGreenToneCurve, profileBlueToneCurve };
             var deviceOetf = new ToneCurve[] { profileRedReverseToneCurve, profileGreenReverseToneCurve, profileBlueReverseToneCurve };
 
             var srgbTrc = IccProfile.Create_sRGB().ReadTag(SafeTagSignature.RedTRCTag)!;
@@ -418,11 +419,13 @@ namespace MHC2Gen
                 mhc2_lut = new double[3, lut_size];
                 for (int ch = 0; ch < 3; ch++)
                 {
+                    var black = deviceEotf[ch].EvalF32(0);
                     for (int iinput = 0; iinput < lut_size; iinput++)
                     {
                         var input = (float)iinput / (lut_size - 1);
                         var linear = outputTrc.EvalF32(input);
-                        var dev_output = deviceOetf[ch].EvalF32(linear);
+                        var linear_bpc = black + linear * (1 - black);
+                        var dev_output = deviceOetf[ch].EvalF32(linear_bpc);
                         if (vcgt != null)
                         {
                             dev_output = vcgt[ch].EvalF32(dev_output);


### PR DESCRIPTION
The ICC profile created by DisplayCal or ArgyllCMS has a non-zero black point (for IPS displays). As result the TRCs at an input of zero has a non-zero value: xTRC(0) > 0. MHC2Gen does not take this into account, which leads to the first few entries in the 1D LUTs being zero and the shadows in that range getting "crushed." This commit fixes the problem.

**Example.** Gradient with levels 0, 1, 2 etc in non-color-managed app (Paint.NET).

MHC-ICC-profile created with latest version of MHC2Gen:
![MHC-ICC-profile created with latest version of MHC2Gen](https://github.com/user-attachments/assets/47e083fe-0674-4997-ac96-5ab7f5e9e15d)

MHC-ICC-profile created with patched version of MHC2Gen:
![MHC-ICC-profile created with patched version of MHC2Gen](https://github.com/user-attachments/assets/2fcea1bc-13bf-4096-af88-0fedb03e660f)

ICC-profile created with ArgyllCMS
[large_d65_xy.zip](https://github.com/user-attachments/files/18208773/large_d65_xy.zip)
